### PR TITLE
Add multi-distribution support for Debian and Arch Linux

### DIFF
--- a/ansible_pull.yml
+++ b/ansible_pull.yml
@@ -46,10 +46,30 @@
     - name: create ansible dir
       file: path=/etc/ansible state=directory owner=root group=root mode=0755
 
-    - name: Install ansible
+    - name: Install ansible (Debian/Ubuntu)
       apt:
-              name: ansible
-              update_cache: yes
+        name: ansible
+        update_cache: yes
+      when: ansible_facts['os_family'] == "Debian"
+
+    - name: Install ansible (Arch Linux)
+      pacman:
+        name: ansible
+        update_cache: yes
+      when: ansible_facts['os_family'] == "Archlinux"
+
+    - name: Install cronie (Arch Linux)
+      pacman:
+        name: cronie
+        state: present
+      when: ansible_facts['os_family'] == "Archlinux"
+
+    - name: Enable and start cronie service (Arch Linux)
+      systemd:
+        name: cronie
+        state: started
+        enabled: yes
+      when: ansible_facts['os_family'] == "Archlinux"
 
     - name: Create local directory to work from
       file: path={{workdir}} state=directory owner=root group=root mode=0751

--- a/local.yml
+++ b/local.yml
@@ -1,24 +1,88 @@
 - hosts: local
 
+  vars:
+    common_packages:
+      - bc
+      - gawk
+      - git
+      - zsh
+      - htop
+      - mtr
+      - curl
+      - most
+      - mosh
+      - nmap
+      - tmux
+      - traceroute
+      - wget
+      - openvpn
+      - direnv
+      - luarocks
+      - unzip
+    debian_specific_packages:
+      - snapd
+      - aptitude
+      - dnsutils
+      - netcat-openbsd
+      - silversearcher-ag
+      - fd-find
+      - python3-neovim
+      - python3
+      - python3-venv
+    arch_specific_packages:
+      - bind-tools  # replaces dnsutils
+      - openbsd-netcat  # replaces netcat-openbsd
+      - the_silver_searcher  # replaces silversearcher-ag
+      - fd  # replaces fd-find
+      - python-pynvim  # replaces python3-neovim
+      - python  # replaces python3
+      - python-virtualenv  # replaces python3-venv
+
   tasks:
-  - name: Install packages
-    apt: 
-      name: ['snapd','bc','gawk','git','zsh','htop','aptitude','mtr','curl','dnsutils','most','mosh','nmap','netcat-openbsd','tmux','traceroute','wget','openvpn', 'silversearcher-ag', 'fd-find', 'direnv','python3-neovim', 'python3', 'luarocks', 'unzip', 'python3-venv']
-      state: present 
-      update_cache: yes
-  - name: Check default editor
-    stat: path=/etc/alternatives/editor
-    register: editor
-  - name: ensure neovim is not there 
-    apt:
-      name: ['neovim']
-      state: absent
-  - name: install neovim snap
-    community.general.snap:
-      name: nvim
-      classic: true
-  - name: Set nvim as the default editor
-    shell: "/usr/sbin/update-alternatives --set editor /snap/bin/nvim || /usr/bin/update-alternatives --set editor /snap/bin/nvim"
-    when: editor.stat.lnk_source != '/usr/bin/nvim'
+    - name: Install common packages
+      package:
+        name: "{{ common_packages }}"
+        state: present
+
+    - name: Install Debian-specific packages
+      package:
+        name: "{{ debian_specific_packages }}"
+        state: present
+      when: ansible_facts['os_family'] == "Debian"
+
+    - name: Install Arch-specific packages
+      package:
+        name: "{{ arch_specific_packages }}"
+        state: present
+      when: ansible_facts['os_family'] == "Archlinux"
+
+    - name: Install neovim (Debian)
+      block:
+        - name: ensure neovim is not there
+          apt:
+            name: ['neovim']
+            state: absent
+        - name: install neovim snap
+          community.general.snap:
+            name: nvim
+            classic: true
+        - name: Set nvim as the default editor (Debian)
+          shell: "/usr/sbin/update-alternatives --set editor /snap/bin/nvim || /usr/bin/update-alternatives --set editor /snap/bin/nvim"
+          when: editor.stat.lnk_source != '/usr/bin/nvim'
+      when: ansible_facts['os_family'] == "Debian"
+
+    - name: Install neovim (Arch)
+      block:
+        - name: Install neovim from pacman
+          package:
+            name: neovim
+            state: present
+        - name: Create symlink for editor
+          file:
+            src: /usr/bin/nvim
+            dest: /usr/local/bin/editor
+            state: link
+      when: ansible_facts['os_family'] == "Archlinux"
+
     #  - name: Install or update starship
     #shell: "curl -sS https://starship.rs/install.sh | sh -s -- -y"


### PR DESCRIPTION
This PR adds support for running the Ansible playbooks on both Debian and Arch Linux systems.\n\nKey changes:\n- Modified ansible_pull.yml to use appropriate package managers (apt/pacman)\n- Added cronie installation and service setup for Arch Linux\n- Refactored local.yml to use distribution-specific package names\n- Split packages into common and distribution-specific groups\n- Updated neovim installation process for both distributions\n\nTesting:\n- Tested in check mode on both a Debian system (rpi4) and an Arch Linux system (tnl.rvdm.net)\n- Verified package name mappings between distributions\n- Ensured cron functionality works on both systems